### PR TITLE
Fix breakout console

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Runs on node and in modern browsers:
 
 |                | Versions |
 | ---            | ---      |
-| **node**       | 4, 6, 8, 10, 11 |
-| **Chrome**     | 69, 71 |
-| **Firefox**    | 60, 64 |
+| **node**       | 8, 10, 11, 12 |
+| **Chrome**     | 70, 75 |
+| **Firefox**    | 60, 68 |
 | **Edge**       | 17, 18 |
 | **IE**         | ~~11~~ |
 | **Safari**     | 11, 12|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safer-eval",
-  "version": "1.3.3",
+  "version": "1.3.4-0",
   "description": "a safer eval",
   "keywords": [
     "eval",
@@ -37,32 +37,32 @@
     "clones": "^1.2.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.4",
-    "@babel/preset-env": "^7.4.4",
+    "@babel/cli": "^7.5.0",
+    "@babel/core": "^7.5.4",
+    "@babel/preset-env": "^7.5.4",
     "babel-loader": "^8.0.6",
-    "eslint": "^5.16.0",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-node": "^9.0.1",
-    "eslint-plugin-promise": "^4.1.1",
+    "eslint": "^6.0.1",
+    "eslint-config-standard": "^13.0.1",
+    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-node": "^9.1.0",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
-    "karma": "^4.1.0",
-    "karma-chrome-launcher": "^2.2.0",
+    "karma": "^4.2.0",
+    "karma-chrome-launcher": "^3.0.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "~0.0.32",
-    "karma-webpack": "^3.0.5",
+    "karma-webpack": "^4.0.2",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3",
-    "webpack": "^4.31.0"
-  },
-  "_devDependencies": {
-    "zuul": "^3.11.1"
+    "webpack": "^4.35.3"
   },
   "engines": {
     "node": ">=6.0.0"
+  },
+  "optionalDevDependencies": {
+    "zuul": "^3.11.1"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -47,13 +47,17 @@ exports.createContext = function () {
     cloneFunctions(context)
     context.Buffer = _protect('Buffer')
     context.console = clones(console, console) // console needs special treatment
+    context.console.constructor.constructor = 'function () {}'
   }
   if (hasWindow) {
     fillContext(window, true)
     cloneFunctions(context)
     protectBuiltInObjects(context)
     context.console = clones(console, console) // console needs special treatment
-    context.Object.constructor.constructor = 'function () {}'
+    try {
+      context.Object.constructor.constructor = 'function () {}'
+    } catch (e) {
+    }
   }
 
   return context
@@ -82,7 +86,7 @@ function cloneFunctions (context) {
     'clearTimeout'
   ].forEach((str) => {
     try {
-      let fn = new Function(`return ${str}`)() // eslint-disable-line no-new-func
+      const fn = new Function(`return ${str}`)() // eslint-disable-line no-new-func
       context[str] = fn
         ? function () {
           return fn.apply(null, [].slice.call(arguments))
@@ -97,7 +101,7 @@ function cloneFunctions (context) {
     'setTimeout'
   ].forEach((str) => {
     try {
-      let fn = new Function(`return ${str}`)() // eslint-disable-line no-new-func
+      const fn = new Function(`return ${str}`)() // eslint-disable-line no-new-func
       context[str] = fn
         ? function (f) {
           if (typeof f === 'function') {
@@ -175,7 +179,7 @@ function protectBuiltInObjects (context) {
 */
 function _protect (str) {
   try {
-    let type = new Function(`return ${str}`)() // eslint-disable-line no-new-func
+    const type = new Function(`return ${str}`)() // eslint-disable-line no-new-func
     return type
       ? clones.classes(type)
       : undefined

--- a/test/saferEval.spec.js
+++ b/test/saferEval.spec.js
@@ -83,8 +83,9 @@ describe('#saferEval', function () {
     })
 
     it('setInterval passing a function', function (done) {
-      var res = saferEval('(function (){var id = setInterval(function () {Array._test = 111;  console.log("intervall"); clearInterval(id)}, 5)}())')
-      assert.strictEqual(res)
+      var res = saferEval('(function (){var id = setInterval(function () {Array._test = 111;  console.log("interval"); clearInterval(id)}, 5)})')
+      assert.strictEqual(typeof res, 'function')
+      res()
       setTimeout(function () {
         assert.strictEqual(Array._test, undefined)
         done()
@@ -270,6 +271,22 @@ describe('#saferEval', function () {
         }
         assert.strictEqual(res, undefined)
       })
+      it('should not allow using console.constructor.constructor', function () {
+        let res
+        try {
+          res = saferEval("console.constructor.constructor('return process')().env")
+        } catch (e) {
+        }
+        assert.strictEqual(res, undefined)
+      })
+      it('should not allow using JSON.constructor.constructor', function () {
+        let res
+        try {
+          res = saferEval("JSON.constructor.constructor('return process')().env")
+        } catch (e) {
+        }
+        assert.strictEqual(res, undefined)
+      })
       it('should prevent a breakout using Object.constructor', function () {
         let res
         try {
@@ -301,7 +318,15 @@ describe('#saferEval', function () {
       it('should not allow using Object.constructor.constructor', function () {
         let res
         try {
-          res = saferEval("Object.constructor.constructor('return localStorage')()")
+          res = saferEval("Object.constructor.constructor('return window')()")
+        } catch (e) {
+        }
+        assert.strictEqual(res, undefined)
+      })
+      it('should not allow using console.constructor.constructor', function () {
+        let res
+        try {
+          res = saferEval("console.constructor.constructor('return window')()")
         } catch (e) {
         }
         assert.strictEqual(res, undefined)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,8 @@ module.exports = {
   devtool: 'source-map',
   resolve: {
     alias: {
-      'src': path.resolve(__dirname, 'src'),
-      'lib': path.resolve(__dirname, 'lib')
+      src: path.resolve(__dirname, 'src'),
+      lib: path.resolve(__dirname, 'lib')
     }
   },
   module: {


### PR DESCRIPTION
A node sandbox breakout was reported using `console.constructor`.
This PR fixes this issue.